### PR TITLE
refactored code to support product list filtering

### DIFF
--- a/js/src/components/Layout/Filter.jsx
+++ b/js/src/components/Layout/Filter.jsx
@@ -1,101 +1,123 @@
-import { useState, useEffect } from 'react';
-
-import productslist from '../productslist';
 import FilterForm from './FilterForm';
 import FilterStatus from './FilterStatus';
 
-export default function Filter() {
-  const [keyword, setKeyword] = useState('');
-  const [selectedCategory, setSelectedCategory] = useState(0);
-  const [saleOnly, setSaleOnly] = useState(false);
-  const [loading, setLoading] = useState(true);
+export default function Filter({
+  keyword,
+  saleOnly,
+  selectedCategory,
+  filteredProducts,
+  handleKeywordChange,
+  handleKeywordReset,
+  handleCategoryChange,
+  handleSaleOnlyChange,
+}) {
+  // ! this logic has to be shared with other components such as the AvailableProducts so we move it up to the mutual parent component Shop
 
-  useEffect(() => {
-    const url = new URL(window.location.href);
+  // const [keyword, setKeyword] = useState('');
+  // const [selectedCategory, setSelectedCategory] = useState(0);
+  // const [saleOnly, setSaleOnly] = useState(false);
+  // const [loading, setLoading] = useState(true);
 
-    const oldKeyword = url.searchParams.get('keyword');
-    if (oldKeyword) {
-      setKeyword(oldKeyword);
-    }
+  // // ! This is what we need for rendering the products
+  // const filteredProducts = useProductFilter(
+  //   productslist,
+  //   keyword,
+  //   selectedCategory,
+  //   saleOnly
+  // );
 
-    const oldSaleOnly = url.searchParams.get('sale');
-    if (oldSaleOnly === 'true') {
-      setSaleOnly(true);
-    }
+  // console.log('*** filteredProducts *** ', filteredProducts)
 
-    const oldCategory = url.searchParams.get('category');
-    if (oldCategory) {
-      setSelectedCategory(parseInt(oldCategory));
-    }
+  // // ! event handlers
+  // const handleKeywordChange = ({ target: { value } }) => setKeyword(value)
+  // const handleKeywordReset = () => setKeyword('')
+  // const handleCategoryChange = ({ target: { value } }) => {
+  //   setSelectedCategory(parseInt(value))
+  // }
+  // const handleSaleOnlyChange = ({ target: { value } }) => setSaleOnly(!value)
 
-    setLoading(false);
-  }, []);
+  // useEffect(() => {
+  //   const url = new URL(window.location.href);
 
-  useEffect(() => {
-    const url = new URL(window.location.href);
+  //   const oldKeyword = url.searchParams.get('keyword');
+  //   if (oldKeyword) {
+  //     setKeyword(oldKeyword);
+  //   }
 
-    url.searchParams.delete('keyword');
+  //   const oldSaleOnly = url.searchParams.get('sale');
+  //   if (oldSaleOnly === 'true') {
+  //     setSaleOnly(true);
+  //   }
 
-    if (keyword) {
-      url.searchParams.set('keyword', keyword);
-    }
+  //   const oldCategory = url.searchParams.get('category');
+  //   if (oldCategory) {
+  //     setSelectedCategory(parseInt(oldCategory));
+  //   }
 
-    url.searchParams.delete('sale');
-    if (saleOnly) {
-      url.searchParams.set('sale', saleOnly);
-    }
+  //   setLoading(false);
+  // }, []);
 
-    url.searchParams.delete('category');
+  // useEffect(() => {
+  //   const url = new URL(window.location.href);
 
-    if (selectedCategory) {
-      url.searchParams.set('category', selectedCategory);
-    }
+  //   url.searchParams.delete('keyword');
 
-    window.history.replaceState({}, '', url);
-  }, [keyword, saleOnly, selectedCategory]);
+  //   if (keyword) {
+  //     url.searchParams.set('keyword', keyword);
+  //   }
 
-  const filteredProducts = getFilteredProducts(
-    productslist,
-    keyword,
-    selectedCategory,
-    saleOnly
-  );
+  //   url.searchParams.delete('sale');
+  //   if (saleOnly) {
+  //     url.searchParams.set('sale', saleOnly);
+  //   }
 
-  if (loading) {
-    return null;
-  }
+  //   url.searchParams.delete('category');
+
+  //   if (selectedCategory) {
+  //     url.searchParams.set('category', selectedCategory);
+  //   }
+
+  //   window.history.replaceState({}, '', url);
+  // }, [keyword, saleOnly, selectedCategory]);
+
+  // if (loading) {
+  //   return null;
+  // }
 
   return (
     <div className="filter">
       <FilterForm
         keyword={keyword}
-        setKeyword={setKeyword}
         selectedCategory={selectedCategory}
-        setSelectedCategory={setSelectedCategory}
         saleOnly={saleOnly}
-        setSaleOnly={setSaleOnly}
+        onKeywordChange={handleKeywordChange}
+        onKeywordReset={handleKeywordReset}
+        onCategoryChange={handleCategoryChange}
+        onSaleOnlyChange={handleSaleOnlyChange}
       />
       <FilterStatus count={filteredProducts.length} />
     </div>
   );
 }
 
-function getFilteredProducts(
-  productslist,
-  keyword,
-  selectedCategory,
-  saleOnly
-) {
-  const keywordRegExp = new RegExp(keyword, 'i');
+// ! this is basically a custom hook so moved it -> src/hooks/useProductFilter.js
 
-  const noKeywordFilter = keyword.length < 2;
-  const noCategoryFilter = selectedCategory === 0;
-  const noSaleFilter = saleOnly === false;
+// function getFilteredProducts(
+//   productslist,
+//   keyword,
+//   selectedCategory,
+//   saleOnly
+// ) {
+//   const keywordRegExp = new RegExp(keyword, 'i');
 
-  const filteredProducts = productslist
-    .filter(({ name }) => noKeywordFilter || keywordRegExp.test(name))
-    .filter(({ category }) => noCategoryFilter || category === selectedCategory)
-    .filter(({ sale }) => noSaleFilter || sale);
+//   const noKeywordFilter = keyword.length < 2;
+//   const noCategoryFilter = selectedCategory === 0;
+//   const noSaleFilter = saleOnly === false;
 
-  return filteredProducts;
-}
+//   const filteredProducts = productslist
+//     .filter(({ name }) => noKeywordFilter || keywordRegExp.test(name))
+//     .filter(({ category }) => noCategoryFilter || category === selectedCategory)
+//     .filter(({ sale }) => noSaleFilter || sale);
+
+//   return filteredProducts;
+// }

--- a/js/src/components/Layout/FilterForm.jsx
+++ b/js/src/components/Layout/FilterForm.jsx
@@ -2,11 +2,12 @@ import { categories } from './../productslist';
 
 export default function FilterForm({
   keyword,
-  setKeyword,
   selectedCategory,
-  setSelectedCategory,
   saleOnly,
-  setSaleOnly,
+  onKeywordChange,
+  onKeywordReset,
+  onCategoryChange,
+  onSaleOnlyChange,
 }) {
   return (
     <form className="filter" onSubmit={(e) => e.preventDefault()}>
@@ -17,13 +18,10 @@ export default function FilterForm({
             type="text"
             id="keyword"
             value={keyword}
-            onChange={(e) => setKeyword(e.target.value)}
+            // no need to use callback function, event is passed in automatically (performance)
+            onChange={onKeywordChange}
           />
-          <button
-            type="button"
-            aria-label="Töröl"
-            onClick={() => setKeyword('')}
-          >
+          <button type="button" aria-label="Töröl" onClick={onKeywordReset}>
             &times;
           </button>
         </div>
@@ -33,7 +31,7 @@ export default function FilterForm({
         <select
           name="category"
           id="category"
-          onChange={(e) => setSelectedCategory(parseInt(e.target.value))}
+          onChange={onCategoryChange}
           value={selectedCategory}
         >
           <option value="0">Összes termék</option>
@@ -49,7 +47,7 @@ export default function FilterForm({
             <input
               type="checkbox"
               checked={saleOnly}
-              onChange={(e) => setSaleOnly(e.target.checked)}
+              onChange={onSaleOnlyChange}
             />
           </label>
         </div>

--- a/js/src/components/Products/AvailableProducts.jsx
+++ b/js/src/components/Products/AvailableProducts.jsx
@@ -1,119 +1,26 @@
-import { useState, useEffect } from 'react';
-
 import Card from '../UI/Card';
 import ProductItem from './ProductItem/ProductItem';
-import productslist from '../productslist';
-import FilterForm from '../Layout/FilterForm';
-import FilterStatus from '../Layout/FilterStatus';
 
-export default function AvailableProducts() {
-  const productsList = productslist.map((product) => (
-    <ProductItem
-      key={product.id}
-      id={product.id}
-      name={product.name}
-      image={product.image}
-      description={product.description}
-      price={product.price}
-    />
-  ));
-
-  const [keyword, setKeyword] = useState('');
-  const [selectedCategory, setSelectedCategory] = useState(0);
-  const [saleOnly, setSaleOnly] = useState(false);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const url = new URL(window.location.href);
-
-    const oldKeyword = url.searchParams.get('keyword');
-    if (oldKeyword) {
-      setKeyword(oldKeyword);
-    }
-
-    const oldSaleOnly = url.searchParams.get('sale');
-    if (oldSaleOnly === 'true') {
-      setSaleOnly(true);
-    }
-
-    const oldCategory = url.searchParams.get('category');
-    if (oldCategory) {
-      setSelectedCategory(parseInt(oldCategory));
-    }
-
-    setLoading(false);
-  }, []);
-
-  useEffect(() => {
-    const url = new URL(window.location.href);
-
-    url.searchParams.delete('keyword');
-
-    if (keyword) {
-      url.searchParams.set('keyword', keyword);
-    }
-
-    url.searchParams.delete('sale');
-    if (saleOnly) {
-      url.searchParams.set('sale', saleOnly);
-    }
-
-    url.searchParams.delete('category');
-
-    if (selectedCategory) {
-      url.searchParams.set('category', selectedCategory);
-    }
-
-    window.history.replaceState({}, '', url);
-  }, [keyword, saleOnly, selectedCategory]);
-
-  const filteredProducts = getFilteredProducts(
-    productslist,
-    keyword,
-    selectedCategory,
-    saleOnly
+export default function AvailableProducts({ filteredProducts }) {
+  // ! we need to loop throug the filtered products not the static data that never changes
+  const productsList = filteredProducts.map(
+    ({ id, name, image, description, price }) => (
+      <ProductItem
+        key={id}
+        id={id}
+        name={name}
+        image={image}
+        description={description}
+        price={price}
+      />
+    )
   );
-
-  if (loading) {
-    return null;
-  }
 
   return (
     <section className="products">
       <Card>
         <ul>{productsList}</ul>
       </Card>
-      <div className="filter">
-        <FilterForm
-          keyword={keyword}
-          setKeyword={setKeyword}
-          selectedCategory={selectedCategory}
-          setSelectedCategory={setSelectedCategory}
-          saleOnly={saleOnly}
-          setSaleOnly={setSaleOnly}
-        />
-        <FilterStatus count={filteredProducts.length} />
-      </div>
     </section>
   );
-}
-
-function getFilteredProducts(
-  productslist,
-  keyword,
-  selectedCategory,
-  saleOnly
-) {
-  const keywordRegExp = new RegExp(keyword, 'i');
-
-  const noKeywordFilter = keyword.length < 2;
-  const noCategoryFilter = selectedCategory === 0;
-  const noSaleFilter = saleOnly === false;
-
-  const filteredProducts = productslist
-    .filter(({ name }) => noKeywordFilter || keywordRegExp.test(name))
-    .filter(({ category }) => noCategoryFilter || category === selectedCategory)
-    .filter(({ sale }) => noSaleFilter || sale);
-
-  return filteredProducts;
 }

--- a/js/src/components/Products/Products.jsx
+++ b/js/src/components/Products/Products.jsx
@@ -1,10 +1,12 @@
 import AvailableProducts from './AvailableProducts';
 import { Fragment } from 'react';
 
-export default function Products() {
+// FIXME - probably unnecessary to have this component in between Store and AvailableProducts
+// ! we are using component drilling and this is a lot of extra code
+export default function Products({ filteredProducts }) {
   return (
     <Fragment>
-      <AvailableProducts />
+      <AvailableProducts filteredProducts={filteredProducts} />
     </Fragment>
   );
 }

--- a/js/src/components/Shop.jsx
+++ b/js/src/components/Shop.jsx
@@ -5,10 +5,40 @@ import Products from './Products/Products';
 import Basket from './Basket/Basket';
 import BasketProvider from '../store/BasketProvider';
 import Filter from './Layout/Filter';
+import productslist from './productslist';
+import { useProductFilter } from '../hooks/useProductFilter';
 
 export default function Shop() {
   const [basketShow, setBasketShow] = useState(false);
 
+  const [keyword, setKeyword] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState(0);
+  const [saleOnly, setSaleOnly] = useState(false);
+  // FIXME - no point of a loading state since this is not async js, everything happens "instantaneously"
+  // ! if you want to add a loading spinner just for astetics you will need to add a setTimeout(() => ..., 2000)
+  const [loading, setLoading] = useState(true);
+
+  // ! This is what we need for rendering the products
+  const filteredProducts = useProductFilter(
+    productslist,
+    keyword,
+    selectedCategory,
+    saleOnly
+  );
+
+  console.log('*** filteredProducts *** ', filteredProducts);
+
+  // ! event handlers
+  const handleKeywordChange = ({ target: { value } }) => setKeyword(value);
+  const handleKeywordReset = () => setKeyword('');
+  const handleCategoryChange = ({ target: { value } }) => {
+    setSelectedCategory(parseInt(value));
+  };
+  const handleSaleOnlyChange = ({ target: { checked } }) =>
+    setSaleOnly(checked);
+
+  // ! not always necessary to have 2 handlers for boolean toggling
+  // ! you could do something like handleToggleBasket(() => setBasketShow(!basketShow))
   const showBasketHandler = () => {
     setBasketShow(true);
   };
@@ -17,13 +47,79 @@ export default function Shop() {
     setBasketShow(false);
   };
 
+  // FIXME
+  // ! I do not see a point in setting/getting URL params. You are not (yet) querying data from a real DB.
+  // ! left it here in case you had plans with it
+
+  // useEffect(() => {
+  //   const url = new URL(window.location.href);
+
+  //   const oldKeyword = url.searchParams.get('keyword');
+  //   if (oldKeyword) {
+  //     setKeyword(oldKeyword);
+  //   }
+
+  //   const oldSaleOnly = url.searchParams.get('sale');
+  //   if (oldSaleOnly === 'true') {
+  //     setSaleOnly(true);
+  //   }
+
+  //   const oldCategory = url.searchParams.get('category');
+  //   if (oldCategory) {
+  //     setSelectedCategory(parseInt(oldCategory));
+  //   }
+
+  //   setLoading(false);
+  // }, []);
+
+  // useEffect(() => {
+  //   const url = new URL(window.location.href);
+
+  //   url.searchParams.delete('keyword');
+
+  //   if (keyword) {
+  //     url.searchParams.set('keyword', keyword);
+  //   }
+
+  //   url.searchParams.delete('sale');
+  //   if (saleOnly) {
+  //     url.searchParams.set('sale', saleOnly);
+  //   }
+
+  //   url.searchParams.delete('category');
+
+  //   if (selectedCategory) {
+  //     url.searchParams.set('category', selectedCategory);
+  //   }
+
+  //   window.history.replaceState({}, '', url);
+  // }, [keyword, saleOnly, selectedCategory]);
+
+  // if (loading) {
+  //   return null;
+  // }
+
   return (
     <BasketProvider>
       {basketShow && <Basket onClose={hideBasketHandler} />}
       <Header onShowBasket={showBasketHandler} />
       <main className="container">
-        <Products />
-        <Filter />
+        <Products
+          // ! this is what you want to use for rendering your product list because these is what we mutate when filtering
+          filteredProducts={filteredProducts}
+        />
+        <Filter
+          // ! This is called component drilling witch can get cumbersome and could lead to poor code readibilty in larger scale apps, but perfect for smaller ones
+          // ! You could move this state logic into the global state (see basket) and use react Context even with a reducer (see flux pattern)
+          keyword={keyword}
+          saleOnly={saleOnly}
+          selectedCategory={selectedCategory}
+          filteredProducts={filteredProducts}
+          handleKeywordChange={handleKeywordChange}
+          handleKeywordReset={handleKeywordReset}
+          handleCategoryChange={handleCategoryChange}
+          handleSaleOnlyChange={handleSaleOnlyChange}
+        />
       </main>
     </BasketProvider>
   );

--- a/js/src/hooks/useProductFilter.js
+++ b/js/src/hooks/useProductFilter.js
@@ -1,0 +1,19 @@
+export function useProductFilter(
+  productslist,
+  keyword,
+  selectedCategory,
+  saleOnly
+) {
+  const keywordRegExp = new RegExp(keyword, 'i');
+
+  const noKeywordFilter = keyword.length < 2;
+  const noCategoryFilter = selectedCategory === 0;
+  const noSaleFilter = saleOnly === false;
+
+  const filteredProducts = productslist
+    .filter(({ name }) => noKeywordFilter || keywordRegExp.test(name))
+    .filter(({ category }) => noCategoryFilter || category === selectedCategory)
+    .filter(({ sale }) => noSaleFilter || sale);
+
+  return filteredProducts;
+}


### PR DESCRIPTION
In order to be able to render the products based on the filter input we have to share the `filteredProducts` array between the `AvailableProducts` and the `Filter` components. So according to this I only had to move the corresponding state up in the mutual parent component, `Shop` and pass it down via props. In the `AvailableProducts` we now loop through the `filteredProducts` array.

See comments in code for details.

Also using react Context + reducer to manage global state is kinda an overkill for a small project like this (though advanced thinking BUT in the beginning quite confusing). Component drilling is sufficient in small applications -> meaning you put the single source of truth (app state) in the root component and pass down the state and event handler callbacks via component props instead of wrapping your app in a provider and sharing the state with every component.

You can delete the `yarn.lock` file. It is just different package manager I use instead of `npm`